### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,11 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  
+  end
+
 
   private
   def item_params

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,4 +1,4 @@
-class Genre < ActiveHash::Base
+class Category < ActiveHash::Base
   self.data = [
     { id: 1, name: '--' },
     { id: 2, name: 'レディース' },

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -18,7 +18,7 @@ class Item < ApplicationRecord
   end
   
   extend ActiveHash::Associations::ActiveRecordExtensions
-  belongs_to :genre
+  belongs_to :category
   belongs_to :item_status
   belongs_to :shipping_fee
   belongs_to :shipping_date

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,14 +128,14 @@
 
       <% @items.each do |item| %>
         <li class='list'>
-          <%= link_to "#" do %>
+          <%= link_to item_path(item.id) do %>
           <div class='item-img-content'>
             <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-            <div class='sold-out'>
-              <span>Sold Out!!</span>
-            </div>
+            <%# <div class='sold-out'> %>
+              <%# <span>Sold Out!!</span> %>
+            <%# </div> %>
           <%# //商品が売れていればsold outを表示しましょう %>
 
           </div>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -50,7 +50,7 @@
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:category_id, Genre.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,0 +1,111 @@
+<%= render "devise/shared/header" %>
+
+<%# 商品の概要 %>
+<div class="item-show">
+  <div class="item-box">
+    <h2 class="name">
+      <%= @item.item_name %>
+    </h2>
+    <div class='item-img-content'>
+      <%= image_tag @item.image,class:"item-box-img" %>
+      <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <%# <div class='sold-out'> %>
+        <%# <span>Sold Out!!</span> %>
+      <%# </div> %>
+      <%# //商品が売れている場合は、sold outを表示しましょう %>
+    </div>
+    <div class="item-price-box">
+      <span class="item-price">
+        ¥ <%= @item.price %>
+      </span>
+      <span class="item-postage">
+        <%= @item.shipping_fee.name %>
+      </span>
+    </div>
+
+    
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+      <% elsif user_signed_in? %>
+        <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% end %>
+      <%# 商品が売れていない場合はこちらを表示しましょう %>
+        <%# <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%> 
+      <%# //商品が売れていない場合はこちらを表示しましょう %>
+    
+    
+
+    <div class="item-explain-box">
+      <span><%= @item.item_profile %></span>
+    </div>
+    <table class="detail-table">
+      <tbody>
+        <tr>
+          <th class="detail-item">出品者</th>
+          <td class="detail-value"><%= @item.user.nickname %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">カテゴリー</th>
+          <td class="detail-value"><%= @item.category.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">商品の状態</th>
+          <td class="detail-value"><%= @item.item_status.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">配送料の負担</th>
+          <td class="detail-value"><%= @item.shipping_fee.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">発送元の地域</th>
+          <td class="detail-value"><%= @item.shipping_erea.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">発送日の目安</th>
+          <td class="detail-value"><%= @item.shipping_date.name %></td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="option">
+      <div class="favorite-btn">
+        <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
+        <span>お気に入り 0</span>
+      </div>
+      <div class="report-btn">
+        <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
+        <span>不適切な商品の通報</span>
+      </div>
+    </div>
+  </div>
+  <%# /商品の概要 %>
+
+  <div class="comment-box">
+    <form>
+      <textarea class="comment-text"></textarea>
+      <p class="comment-warn">
+        相手のことを考え丁寧なコメントを心がけましょう。
+        <br>
+        不快な言葉遣いなどは利用制限や退会処分となることがあります。
+      </p>
+      <button type="submit" class="comment-btn">
+        <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
+        <span>コメントする<span>
+      </button>
+    </form>
+  </div>
+  <div class="links">
+    <a href="#" class="change-item-btn">
+      ＜ 前の商品
+    </a>
+    <a href="#" class="change-item-btn">
+      後ろの商品 ＞
+    </a>
+  </div>
+  
+  <a href=“#” class=‘another-item’><%= @item.category.name %>をもっと見る</a>
+  
+</div>
+
+<%= render "devise/shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,5 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: "items#index"
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
 end


### PR DESCRIPTION
#what
商品詳細表示機能
#why
商品詳細表示機能実装のため

・ログイン状態の出品者のみ、「編集・削除ボタン」が表示されること
https://i.gyazo.com/0ab27461cd1a86ba720b27f270145a85.gif
・ログイン状態の出品者以外のユーザーのみ、「購入画面に進むボタン」が表示されること
https://i.gyazo.com/dde9afaa615fd4ef2decc88ccb7065df.gif
・ログアウト状態のユーザーでも、商品詳細表示ページを閲覧できることとログアウト状態のユーザーには、「編集・削除・購入画面に進むボタン」が表示されないこと
https://i.gyazo.com/cc6d686774988fcb9e59b9b8c9383045.gif

※「ログイン状態の出品者でも、売却済みの商品に対しては「編集・削除ボタン」が表示されないこと」に関して
こちらは、購入機能に関して何も手をつけていない状態ですが、それでも現時点で実装可能でしょうか？